### PR TITLE
Update refresh icon to unicode

### DIFF
--- a/ajax.toolkit.php
+++ b/ajax.toolkit.php
@@ -485,7 +485,7 @@ try
 			}
 		}
 			echo "</select>\n";
-			echo "<input type=\"button\" value=\"↻ ⟳ Refresh\" onclick=\"CheckDictionary(true);\"/>\n";
+			echo "<input type=\"button\" value=\"⟳ Refresh\" onclick=\"CheckDictionary(true);\"/>\n";
 			echo "<textarea style=\"width:100%;height:400px;\">";
 			echo MakeDictionaryTemplate($sModules, $sDefaultCode);
 			echo "</textarea>\n";
@@ -564,7 +564,7 @@ try
 			{
 				echo "<p><input type=\"checkbox\" id=\"symlink\" value=\"1\"><label for=\"symlink\">&nbsp;Create symbolic links instead of creating a copy in env-production (useful for debugging extensions)</label></p>\n";
 			}
-			echo "<input type=\"button\" value=\"↻ ⟳ Refresh \" onclick=\"CheckDBSchema(true);\"/>\n";
+			echo "<input type=\"button\" value=\"⟳ Refresh\" onclick=\"CheckDBSchema(true);\"/>\n";
 			if (count($aSQLFixesTables) > 0)
 			{
 				echo "<input type=\"submit\" onclick=\"doApply(true);\"title=\"Compile + Update DB tables and views\" value=\"📀 Update iTop code and Database! \"/>&nbsp;<span id=\"apply_sql_indicator\"></span>\n";


### PR DESCRIPTION
To continue the conversation of https://github.com/Combodo/itop-toolkit-community/commit/8c13af682687ed19a15e8d36cd9476d50609730e#r41809250

The 🔄 ([U+1F504](https://emojipedia.org/counterclockwise-arrows-button/)) icon looks like a button on most platforms, and thus it's not a good choice to place on a button.

I currently added both unicode icons that apply as plain unicode alternative:

- ↻ ([U+21BB](https://unicode-table.com/en/21BB/))
- ⟳ ([U+27F3](https://unicode-table.com/en/27F3/))

MacOS Safari:
<img width="90" alt="image" src="https://user-images.githubusercontent.com/228588/92589815-69f8ff00-f29b-11ea-9d20-8a58a890178c.png">
MacOS Chrome:
<img width="113" alt="image" src="https://user-images.githubusercontent.com/228588/92589912-9a409d80-f29b-11ea-8e48-c4194cf0e2b2.png">
MacOS Firefox:
<img width="115" alt="image" src="https://user-images.githubusercontent.com/228588/92589955-ab89aa00-f29b-11ea-9833-cae5d3ef90ac.png">

If someone could show these examples from other systems, that would be nice.